### PR TITLE
Clean up some syntax and add path checking to make DerpibooruDL a bit more robust as a CLI application

### DIFF
--- a/derpiboorudl.py
+++ b/derpiboorudl.py
@@ -10,9 +10,6 @@ import os.path
 import sys
 
 logger = None
-destdir = ""
-query = ""
-maximages = 100
 
 def setup_logger(log):
     log.setLevel(logging.DEBUG)
@@ -24,35 +21,37 @@ def setup_logger(log):
     ch.setFormatter(formatter)
     log.addHandler(ch)
 
-logger = logging.getLogger("derpiboorudl")
-setup_logger(logger)
+def main():
+    logger = logging.getLogger("derpiboorudl")
+    setup_logger(logger)
 
-# Read API key from env (will get overriden by --key option when given)
-apikey = os.getenv("DERPIBOORUAPIKEY")
+    # Parse args
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--destdir", required=True, help="Location where downloaded images will be dropped off")
+    parser.add_argument("-q", "--query", default="", help="The Derpibooru query you wish to execute")
+    parser.add_argument("-c", "--count", default=100, help="The count of images you wish to download", type=int)
+    parser.add_argument("-k", "--key", default=None, help="Specify the API key (normally present as env variable)")
+    args = parser.parse_args()
 
-# Parse args
-parser = argparse.ArgumentParser()
-parser.add_argument("destdir", help="Location where downloaded images will be dropped off")
-parser.add_argument("query", help="The Derpibooru query you wish to execute")
-parser.add_argument("--count", help="The count of images you wish to download", type=int)
-parser.add_argument("--key", help="Specify the API key (normally present as env variable)")
-args = parser.parse_args()
+    destdir, query, maximages = args.destdir, args.query, args.count
+ 
+    # Read API key from --key if present or else read from env
+    apikey = args.key if args.key else os.getenv("DERPIBOORUAPIKEY")
 
-destdir = args.destdir 
-query = args.query 
+    if not apikey:
+        logger.info("No API key was set! (DERPIBOORUAPIKEY)")
 
-if args.count:
-    maximages = args.count
+    search = Search().key(apikey).query(query).limit(maximages)
 
-if args.key:
-    apikey = args.key
+    if not os.path.isdir(destdir):
+        os.mkdir(destdir)
 
-if apikey is None:
-    logger.info("No API key was set! (DERPIBOORUAPIKEY)")
+    for image in search:
+        filename = os.path.basename(image.full)
+        path = os.path.join(destdir, filename)
+        if not os.path.isfile(path):
+            logger.info("Now downloading image with id {0}".format(image.id_number))
+            urllib.urlretrieve(image.full, path)
 
-for image in Search().key(apikey).query(query).limit(maximages):
-    filename = os.path.basename(image.full)
-    path = os.path.join(destdir, filename)
-    if not os.path.isfile(path):
-        logger.info("Now downloading image with id {0}".format(image.id_number))
-        urllib.urlretrieve(image.full, path)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A few notable additions I've made:
- Put application code into main() so that importing the module outside **main**() doesn't execute it
- Leverage argparse's default options and switch arguments to save a few lines that were otherwise used toward testing for the existence of options
- Instantiate multiple variables in one line since they're all related to argparse
- Use the slightly more concise "if not apikey" syntax over "if apikey is None"
- Use path creation in case of the very likely possibility that the file destination doesn't exist
