### PR TITLE
Add python3.x compatibility and more robust downloading

### DIFF
--- a/derpiboorudl.py
+++ b/derpiboorudl.py
@@ -2,6 +2,7 @@
 
 from derpibooru import Search
 from requests import get, codes
+from hashlib import sha512
 
 import argparse
 import logging
@@ -11,15 +12,17 @@ import sys
 
 logger = None
 
-def download_file(url, fname):
-    r, chunk_size = get(url, stream=True), 1024
+def sha512_hash(f):
+    h = sha512()
+
+    h.update(f)
+    return h.hexdigest()
+
+def download_file(url):
+    r = get(url)
 
     if r.status_code == codes.ok:
-        with open(fname, "wb") as f:
-            for chunk in r.iter_content(chunk_size): 
-                f.write(chunk)
-
-        return fname
+        return r.content
 
 def setup_logger(log):
     log.setLevel(logging.DEBUG)
@@ -61,7 +64,18 @@ def main():
         path = os.path.join(destdir, filename)
         if not os.path.isfile(path):
             logger.info("Now downloading image with id {0}".format(image.id_number))
-            download_file(image.full, path)            
+
+            download = download_file(image.full)
+            if download:
+                if image.sha512_hash == sha512_hash(download):
+                    with open(path, "wb") as f:
+                        f.write(download)
+                else:
+                    logger.error("sha512 hashes for {0} don't match up".format(image.id_number))
+            else:
+                logger.error("download for {0} didn't complete".format(image.id_number))
+
 
 if __name__ == "__main__":
     main()
+

--- a/derpiboorudl.py
+++ b/derpiboorudl.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python
 
 from derpibooru import Search
+from requests import get, codes
 
 import argparse
 import logging
-import urllib
 import os
 import os.path
 import sys
 
 logger = None
+
+def download_file(url, fname):
+    r, chunk_size = get(url, stream=True), 1024
+
+    if r.status_code == codes.ok:
+        with open(fname, "wb") as f:
+            for chunk in r.iter_content(chunk_size): 
+                f.write(chunk)
+
+        return fname
 
 def setup_logger(log):
     log.setLevel(logging.DEBUG)
@@ -51,7 +61,7 @@ def main():
         path = os.path.join(destdir, filename)
         if not os.path.isfile(path):
             logger.info("Now downloading image with id {0}".format(image.id_number))
-            urllib.urlretrieve(image.full, path)
+            download_file(image.full, path)            
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Since the Requests library is compatible with both Python 2.7 and 3.x and is a dependency of DerPyBooru anyway, using that instead of standard urllib module would be sensible so that the same code can run on newer versions.

I've also tweaked the downloading behavior where it won't write to file until the download is finished, that way incomplete files don't get written if the program is terminated prematurely.

Lastly, I've added a sha512 checksum test to ensure that the downloaded file is correct and not tampered before being saved, otherwise the file write is skipped.
